### PR TITLE
Fix compilation for Chisel 3.6.0

### DIFF
--- a/src/main/scala/fudian/FADD.scala
+++ b/src/main/scala/fudian/FADD.scala
@@ -31,12 +31,12 @@ class FarPath(val expWidth: Int, val precision: Int, val outPc: Int)
   val adder_in_sig_a = Cat(0.U(1.W), a.sig, 0.U(3.W))
   val adder_result =
     adder_in_sig_a +
-      Mux(effSub, ~adder_in_sig_b, adder_in_sig_b).asUInt() + effSub
+      Mux(effSub, ~adder_in_sig_b, adder_in_sig_b).asUInt + effSub
 
   val exp_a_plus_1 = a.exp + 1.U
   val exp_a_minus_1 = a.exp - 1.U
 
-  val cout = adder_result.head(1).asBool()
+  val cout = adder_result.head(1).asBool
   val keep = adder_result.head(2) === 1.U
   val cancellation = adder_result.head(2) === 0.U
 
@@ -52,9 +52,9 @@ class FarPath(val expWidth: Int, val precision: Int, val outPc: Int)
   val far_path_sticky = Mux1H(
     Seq(cout, keep || smallAdd, cancellation && !smallAdd),
     Seq(
-      adder_result.tail(precision + 1).orR(),
-      adder_result.tail(precision + 2).orR(),
-      adder_result.tail(precision + 3).orR()
+      adder_result.tail(precision + 1).orR,
+      adder_result.tail(precision + 2).orR,
+      adder_result.tail(precision + 3).orR
     )
   )
 
@@ -103,46 +103,46 @@ class NearPath(val expWidth: Int, val precision: Int, val outPc: Int)
   val (a, b) = (io.in.a, io.in.b)
   val need_shift = io.in.need_shift_b
   val a_sig = Cat(a.sig, 0.U(1.W))
-  val b_sig = (Cat(b.sig, 0.U(1.W)) >> need_shift).asUInt()
-  val b_neg = (~b_sig).asUInt()
+  val b_sig = (Cat(b.sig, 0.U(1.W)) >> need_shift).asUInt
+  val b_neg = (~b_sig).asUInt
   // extend 1 bit to get 'a_lt_b'
   val a_minus_b = Cat(0.U(1.W), a_sig) + Cat(1.U(1.W), b_neg) + 1.U
-  val a_lt_b = a_minus_b.head(1).asBool()
+  val a_lt_b = a_minus_b.head(1).asBool
   val sig_raw = a_minus_b.tail(1)
   val lza_ab = Module(new LZA(precision + 1))
   lza_ab.io.a := a_sig
   lza_ab.io.b := b_neg
   val lza_str = lza_ab.io.f
-  val lza_str_zero = !Cat(lza_str).orR()
+  val lza_str_zero = !Cat(lza_str).orR
 
   // need to limit the shamt? (if a.exp is not large enough, a.exp-lzc may < 1)
   val need_shift_lim = a.exp < (precision + 1).U
   val mask_table_k_width = log2Up(precision + 1)
   val shift_lim_mask_raw = ((
     Cat(true.B, 0.U((precision + 1).W)) >> a.exp(mask_table_k_width - 1, 0)
-    ).asUInt())(precision , 0)
+    ).asUInt)(precision , 0)
   val shift_lim_mask = Mux(need_shift_lim, shift_lim_mask_raw, 0.U)
-  val shift_lim_bit = (shift_lim_mask_raw & sig_raw).orR()
+  val shift_lim_bit = (shift_lim_mask_raw & sig_raw).orR
 
   val lzc_str = shift_lim_mask | lza_str
   val lzc = CLZ(lzc_str)
 
   val int_bit_mask = Cat((0 until precision + 1).reverseMap {
     case i @ `precision` => lzc_str(i)
-    case i               => lzc_str(i) & !lzc_str.head(precision + 1 - i - 1).orR()
+    case i               => lzc_str(i) & !lzc_str.head(precision + 1 - i - 1).orR
   })
 
   val int_bit_predicted =
-    ((int_bit_mask | lza_str_zero) & sig_raw).orR()
+    ((int_bit_mask | lza_str_zero) & sig_raw).orR
   val int_bit_rshift_1 =
-    ((int_bit_mask >> 1.U).asUInt() & sig_raw).orR()
+    ((int_bit_mask >> 1.U).asUInt & sig_raw).orR
 
   val exceed_lim_mask = Cat((0 until precision + 1).reverseMap {
     case `precision` => false.B
-    case i           => lza_str.head(precision + 1 - i - 1).orR()
+    case i           => lza_str.head(precision + 1 - i - 1).orR
   })
   val exceed_lim =
-    need_shift_lim && !(exceed_lim_mask & shift_lim_mask_raw).orR()
+    need_shift_lim && !(exceed_lim_mask & shift_lim_mask_raw).orR
 
   val int_bit =
     Mux(exceed_lim, shift_lim_bit, int_bit_rshift_1 || int_bit_predicted)
@@ -226,7 +226,7 @@ class FCMA_ADD(val expWidth: Int, val precision: Int, val outPc: Int)
   val exp_diff_a_b = Cat(0.U(1.W), raw_a.exp) - Cat(0.U(1.W), raw_b.exp)
   val exp_diff_b_a = Cat(0.U(1.W), raw_b.exp) - Cat(0.U(1.W), raw_a.exp)
   // `b_overflow` means mul result is much bigger than a
-  val need_swap = exp_diff_a_b.head(1).asBool() || b_flags.overflow
+  val need_swap = exp_diff_a_b.head(1).asBool || b_flags.overflow
 
   val ea_minus_eb = Mux(need_swap, exp_diff_b_a.tail(1), exp_diff_a_b.tail(1))
   val sel_far_path = !eff_sub || ea_minus_eb > 1.U || b_flags.overflow
@@ -335,7 +335,7 @@ class FCMA_ADD(val expWidth: Int, val precision: Int, val outPc: Int)
     near_path_sig_rounded
   )
 
-  val near_path_of = near_path_exp_rounded === (~0.U(expWidth.W)).asUInt()
+  val near_path_of = near_path_exp_rounded === (~0.U(expWidth.W)).asUInt
   val near_path_ix = near_path_rounder.io.inexact || near_path_of
   val near_path_uf = near_path_out.tininess && near_path_ix
 

--- a/src/main/scala/fudian/FCMA.scala
+++ b/src/main/scala/fudian/FCMA.scala
@@ -22,7 +22,7 @@ class FCMA(val expWidth: Int, val precision: Int) extends Module {
 
   val mul_to_fadd = fmul.io.to_fadd
   fadd.io.a := Cat(io.c, 0.U(precision.W))
-  fadd.io.b := mul_to_fadd.fp_prod.asUInt()
+  fadd.io.b := mul_to_fadd.fp_prod.asUInt
   fadd.io.b_inter_valid := true.B
   fadd.io.b_inter_flags := mul_to_fadd.inter_flags
   fadd.io.rm := io.rm

--- a/src/main/scala/fudian/FCMP.scala
+++ b/src/main/scala/fudian/FCMP.scala
@@ -24,7 +24,7 @@ class FCMP(val expWidth: Int, val precision: Int) extends Module {
   val same_sign = fp_a.sign === fp_b.sign
   val a_minus_b = Cat(0.U(1.W), a) - Cat(0.U(1.W), b)
   val uint_eq = a_minus_b.tail(1) === 0.U
-  val uint_less = fp_a.sign ^ a_minus_b.head(1).asBool()
+  val uint_less = fp_a.sign ^ a_minus_b.head(1).asBool
 
   val invalid = hasSNaN || (io.signaling && hasNaN)
 

--- a/src/main/scala/fudian/FDIV.scala
+++ b/src/main/scala/fudian/FDIV.scala
@@ -309,8 +309,8 @@ class FDIV(val expWidth: Int, val precision: Int) extends Module {
   // post_1
   val r = Mux(sqrtReg, SignExt(sqrtModule.io.rem, itn_len+1), SignExt(divModule.io.rem, itn_len+1)) // TODO fix this
   val qFinal = Mux(r.head(1).asBool, quotM1Iter, quotIter) //
-  val sticky = (r.orR()) || (needShiftReg && qFinal(0)) // if non-zero remainder( which must be positive), we
-  val round = Mux(needShiftReg, qFinal(1).asBool(), qFinal(0).asBool)
+  val sticky = (r.orR) || (needShiftReg && qFinal(0)) // if non-zero remainder( which must be positive), we
+  val round = Mux(needShiftReg, qFinal(1).asBool, qFinal(0).asBool)
   val rounder = Module(new RoundingUnit(precision-1))
   rounder.io.in := Mux(needShiftReg, qFinal(precision, 2), qFinal(precision-1, 1))
   rounder.io.stickyIn := sticky

--- a/src/main/scala/fudian/FMUL.scala
+++ b/src/main/scala/fudian/FMUL.scala
@@ -53,7 +53,7 @@ class FMUL(val expWidth: Int, val precision: Int) extends Module {
   val prod_exp = exp_sum - (biasInt - (paddingBits + 1)).U
 
   val shift_lim_sub = Cat(0.U(1.W), exp_sum) - (biasInt - paddingBits).U
-  val prod_exp_uf = shift_lim_sub.head(1).asBool()
+  val prod_exp_uf = shift_lim_sub.head(1).asBool
   val shift_lim = shift_lim_sub.tail(1)
   // ov <=> exp_a + exp_b - bias > max_exp
   val prod_exp_ov = exp_sum >
@@ -68,8 +68,8 @@ class FMUL(val expWidth: Int, val precision: Int) extends Module {
   val sig_shifter_in = Cat(padding, prod)
   val sig_shifted_raw = (sig_shifter_in << shift_amt)(paddingBits + 2 * precision - 1, 0)
   val exp_shifted = prod_exp - shift_amt
-  val exp_is_subnormal = (exceed_lim || prod_exp_uf) && !sig_shifted_raw.head(1).asBool()
-  val no_extra_shift = sig_shifted_raw.head(1).asBool() || exp_is_subnormal
+  val exp_is_subnormal = (exceed_lim || prod_exp_uf) && !sig_shifted_raw.head(1).asBool
+  val no_extra_shift = sig_shifted_raw.head(1).asBool || exp_is_subnormal
 
   val exp_pre_round = Mux(exp_is_subnormal, 0.U, Mux(no_extra_shift, exp_shifted, exp_shifted - 1.U))
   val sig_shifted = Mux(no_extra_shift, sig_shifted_raw, Cat(sig_shifted_raw.tail(1), 0.U(1.W)))
@@ -156,7 +156,7 @@ class FMUL(val expWidth: Int, val precision: Int) extends Module {
   io.to_fadd.fp_prod.exp := Mux(hasZero, 0.U, exp_pre_round)
   io.to_fadd.fp_prod.sig := Mux(hasZero,
     0.U,
-    sig_shifted.tail(1).head(2 * precision - 1) | sig_shifted.tail(2 * precision).orR()
+    sig_shifted.tail(1).head(2 * precision - 1) | sig_shifted.tail(2 * precision).orR
   )
   io.to_fadd.inter_flags.isInv := special_iv
   io.to_fadd.inter_flags.isInf := hasInf && !nan_result

--- a/src/main/scala/fudian/FPToFP.scala
+++ b/src/main/scala/fudian/FPToFP.scala
@@ -68,14 +68,14 @@ class FPDownConverter(
   val fp_in = FloatPoint.fromUInt(io.in, inExpWidth, inPrecision)
   val decode = fp_in.decode
   val raw_in = RawFloat.fromFP(fp_in, Some(decode.expNotZero))
-  val down_exp = fp_in.exp.zext() - exp_delta.S
+  val down_exp = fp_in.exp.zext - exp_delta.S
 
   /*
       Normal path
    */
   val normal_sig = fp_in.sig.head(outPrecision - 1)
-  val normal_roundBit = fp_in.sig.tail(outPrecision - 1).head(1).asBool()
-  val normal_stickyBit = fp_in.sig.tail(outPrecision).orR()
+  val normal_roundBit = fp_in.sig.tail(outPrecision - 1).head(1).asBool
+  val normal_stickyBit = fp_in.sig.tail(outPrecision).orR
 
   val normal_rounder = Module(new RoundingUnit(outPrecision - 1))
   normal_rounder.io.in := normal_sig

--- a/src/main/scala/fudian/FPToInt.scala
+++ b/src/main/scala/fudian/FPToInt.scala
@@ -41,7 +41,7 @@ class FPToInt(val expWidth: Int, val precision: Int) extends Module {
   val lpath_iv = !is_signed_int && raw_a.sign
   val lpath_may_of = is_signed_int && (raw_a.exp === max_int_exp)
   val lpath_pos_of = lpath_may_of && !raw_a.sign
-  val lpath_neg_of = lpath_may_of && raw_a.sign && raw_a.sig.tail(1).orR()
+  val lpath_neg_of = lpath_may_of && raw_a.sign && raw_a.sig.tail(1).orR
   val lpath_of = lpath_pos_of || lpath_neg_of
 
   /*
@@ -64,10 +64,10 @@ class FPToInt(val expWidth: Int, val precision: Int) extends Module {
     rpath_rounder.io.out
   )
   val rpath_ix = rpath_rounder.io.inexact
-  val rpath_iv = !is_signed_int && raw_a.sign && rpath_sig.orR()
+  val rpath_iv = !is_signed_int && raw_a.sign && rpath_sig.orR
   val rpath_of = if (precision >= 32) {
     val rpath_exp_inc =
-      rpath_rounder.io.r_up && rpath_rounder.io.in(30, 0).andR()
+      rpath_rounder.io.r_up && rpath_rounder.io.in(30, 0).andR
     val rpath_exp_eq_31 = raw_a.exp === (FloatPoint.expBias(expWidth) + 31).U
     val rpath_exp_eq_30 = raw_a.exp === (FloatPoint.expBias(expWidth) + 30).U
     val rpath_pos_of = !raw_a.sign && Mux(
@@ -76,7 +76,7 @@ class FPToInt(val expWidth: Int, val precision: Int) extends Module {
       rpath_exp_eq_31 && rpath_exp_inc
     )
     val rpath_neg_of = raw_a.sign && rpath_exp_eq_31 &&
-      (rpath_rounder.io.in(30, 0).orR() || rpath_rounder.io.r_up)
+      (rpath_rounder.io.in(30, 0).orR || rpath_rounder.io.r_up)
     // only for int32
     !is_long_int && (rpath_pos_of || rpath_neg_of)
   } else false.B

--- a/src/main/scala/fudian/IntToFP.scala
+++ b/src/main/scala/fudian/IntToFP.scala
@@ -32,7 +32,7 @@ class IntToFP_prenorm extends Module {
   val in_sign = signed_int && Mux(long_int, in(63), in(31))
   val in_sext = Cat(Fill(32, in(31)), in(31, 0))
   val in_raw = Mux(signed_int && !long_int, in_sext, in)
-  val in_abs = Mux(in_sign, (~in_raw).asUInt() + 1.U, in_raw)
+  val in_abs = Mux(in_sign, (~in_raw).asUInt + 1.U, in_raw)
 
   val lza = Module(new LZA(64))
   lza.io.a := 0.U
@@ -46,11 +46,11 @@ class IntToFP_prenorm extends Module {
   // eg: 001010 => 001000
   val one_mask = Cat((0 until 64).reverseMap {
     case i @ 63 => lza.io.f(i)
-    case i @ 0  => !lza.io.f(63, i + 1).orR()
-    case i      => lza.io.f(i) && !lza.io.f(63, i + 1).orR()
+    case i @ 0  => !lza.io.f(63, i + 1).orR
+    case i      => lza.io.f(i) && !lza.io.f(63, i + 1).orR
   })
 
-  val lzc_error = Mux(in_sign, !(in_abs & one_mask).orR(), false.B)
+  val lzc_error = Mux(in_sign, !(in_abs & one_mask).orR, false.B)
 
   val in_shift_s1 = (in_abs << lzc)(62, 0)
   val in_norm = Mux(lzc_error, Cat(in_shift_s1.tail(1), 0.U(1.W)), in_shift_s1)
@@ -75,7 +75,7 @@ class IntToFP_postnorm(val expWidth: Int, val precision: Int) extends Module {
   val exp_raw = (63 + FloatPoint.expBias(expWidth)).U(expWidth.W) - lzc
   val sig_raw = in.head(precision - 1) // exclude hidden bit
   val round_bit = in.tail(precision - 1).head(1)
-  val sticky_bit = in.tail(precision).orR()
+  val sticky_bit = in.tail(precision).orR
 
   val rounder = Module(new RoundingUnit(precision - 1))
   rounder.io.in := sig_raw

--- a/src/main/scala/fudian/RoundingUnit.scala
+++ b/src/main/scala/fudian/RoundingUnit.scala
@@ -16,7 +16,7 @@ class RoundingUnit(val width: Int) extends Module {
     val r_up = Output(Bool())
   })
 
-  val (g, r, s) = (io.in(0).asBool(), io.roundIn, io.stickyIn)
+  val (g, r, s) = (io.in(0).asBool, io.roundIn, io.stickyIn)
   val inexact = r | s
   val r_up = MuxLookup(
     io.rm,
@@ -33,7 +33,7 @@ class RoundingUnit(val width: Int) extends Module {
   io.out := Mux(r_up, out_r_up, io.in)
   io.inexact := inexact
   // r_up && io.in === 111...1
-  io.cout := r_up && io.in.andR()
+  io.cout := r_up && io.in.andR
   io.r_up := r_up
 }
 
@@ -43,8 +43,8 @@ object RoundingUnit {
     val in_pad = if(in.getWidth < width + 2) padd_tail(in, width + 2) else in
     val rounder = Module(new RoundingUnit(width))
     rounder.io.in := in_pad.head(width)
-    rounder.io.roundIn := in_pad.tail(width).head(1).asBool()
-    rounder.io.stickyIn := in_pad.tail(width + 1).orR()
+    rounder.io.roundIn := in_pad.tail(width).head(1).asBool
+    rounder.io.stickyIn := in_pad.tail(width + 1).orR
     rounder.io.rm := rm
     rounder.io.signIn := sign
     rounder

--- a/src/main/scala/fudian/package.scala
+++ b/src/main/scala/fudian/package.scala
@@ -29,9 +29,9 @@ package object fudian {
     val exp = UInt(expWidth.W)
     val sig = UInt(sigWidth.W)
     def decode: FPDecodeBundle = {
-      val expNotZero = exp.orR()
-      val expIsOnes = exp.andR()
-      val sigNotZero = sig.orR()
+      val expNotZero = exp.orR
+      val expIsOnes = exp.andR
+      val sigNotZero = sig.orR
       val bundle = Wire(new FPDecodeBundle)
       bundle.expNotZero := expNotZero
       bundle.expIsZero := !expNotZero
@@ -42,8 +42,8 @@ package object fudian {
       bundle.isInf := bundle.expIsOnes && bundle.sigIsZero
       bundle.isZero := bundle.expIsZero && bundle.sigIsZero
       bundle.isNaN := bundle.expIsOnes && bundle.sigNotZero
-      bundle.isSNaN := bundle.isNaN && !sig.head(1).asBool()
-      bundle.isQNaN := bundle.isNaN && sig.head(1).asBool()
+      bundle.isSNaN := bundle.isNaN && !sig.head(1).asBool
+      bundle.isQNaN := bundle.isNaN && sig.head(1).asBool
       bundle
     }
   }
@@ -78,7 +78,7 @@ package object fudian {
   object RawFloat {
     def fromFP(fp: FloatPoint, expNotZero: Option[Bool] = None): RawFloat = {
       val inner = Wire(new RawFloat(fp.expWidth, fp.precision))
-      val nz = if (expNotZero.isDefined) expNotZero.get else fp.exp.orR()
+      val nz = if (expNotZero.isDefined) expNotZero.get else fp.exp.orR
       inner.sign := fp.sign
       inner.exp := fp.exp | !nz
       inner.sig := Cat(nz, fp.sig)

--- a/src/main/scala/fudian/utils/CLZ.scala
+++ b/src/main/scala/fudian/utils/CLZ.scala
@@ -14,7 +14,7 @@ class CLZ(len: Int, zero: Boolean) extends Module {
     val out = Output(UInt(outWidth.W))
   })
 
-  io.out := PriorityEncoder(io.in.asBools().reverse)
+  io.out := PriorityEncoder(io.in.asBools.reverse)
 }
 
 object CLZ {

--- a/src/main/scala/fudian/utils/ShiftRightJam.scala
+++ b/src/main/scala/fudian/utils/ShiftRightJam.scala
@@ -17,9 +17,9 @@ class ShiftRightJam(val len: Int) extends Module {
   val exceed_max_shift = io.shamt > len.U
   val shamt = io.shamt(max_shift_width - 1, 0)
   val sticky_mask =
-    ((1.U << shamt).asUInt() - 1.U)(len - 1, 0) | Fill(len, exceed_max_shift)
+    ((1.U << shamt).asUInt - 1.U)(len - 1, 0) | Fill(len, exceed_max_shift)
   io.out := Mux(exceed_max_shift, 0.U, io.in >> io.shamt)
-  io.sticky := (io.in & sticky_mask).orR()
+  io.sticky := (io.in & sticky_mask).orR
 }
 
 object ShiftRightJam {


### PR DESCRIPTION
Remove deprecated usage of redundant parentheses.