### PR TITLE
chore: replace deprecated APIs

### DIFF
--- a/src/main/scala/fudian/FDIV.scala
+++ b/src/main/scala/fudian/FDIV.scala
@@ -376,8 +376,8 @@ class DivIterModule(len: Int, itn_len: Int) extends Module {
   val (a, d) = (io.a, io.d)
   val lookup = d(len-2, len-4)
 
-  val smallerThanM1 = (wsInit.head(7)(4, 0) + MuxLookup(lookup(2,0), 0.U, mLookupTable.minus_m(2))).head(1).asBool
-  val smallerThanM2 = (wsInit.head(7)(4, 0) + MuxLookup(lookup(2,0), 0.U, mLookupTable.minus_m(3))).head(1).asBool
+  val smallerThanM1 = (wsInit.head(7)(4, 0) + MuxLookup(lookup(2,0), 0.U)(mLookupTable.minus_m(2))).head(1).asBool
+  val smallerThanM2 = (wsInit.head(7)(4, 0) + MuxLookup(lookup(2,0), 0.U)(mLookupTable.minus_m(3))).head(1).asBool
 
   val qInit = Mux(smallerThanM1, UIntToOH(quot_0), Mux(smallerThanM2, UIntToOH(quot_pos_1), UIntToOH(quot_pos_2)))
 
@@ -422,7 +422,7 @@ class DivIterModule(len: Int, itn_len: Int) extends Module {
 
   // Give values to the regs and wires above...
   mNeg := VecInit(Seq.tabulate(4){i =>
-    Cat(SignExt(MuxLookup(lookup(2,0), 0.U, mLookupTable.minus_m(i)), 10), 0.U(2.W))
+    Cat(SignExt(MuxLookup(lookup(2,0), 0.U)(mLookupTable.minus_m(i)), 10), 0.U(2.W))
   }) // (2, 4) -> (6, 6)
 
   udNeg := VecInit(
@@ -548,7 +548,7 @@ class SqrtIterModule(len: Int, itn_len: Int) extends Module { // itn_len == len 
   val lookup = Mux(j === 1.U, "b101".U, aHeadReg)(2, 0)
 
   val mNeg = VecInit(Seq.tabulate(4){i =>
-    Cat(SignExt(MuxLookup(lookup(2,0), 0.U, mLookupTable2.minus_m(i)), 7), 0.U(1.W))
+    Cat(SignExt(MuxLookup(lookup(2,0), 0.U)(mLookupTable2.minus_m(i)), 7), 0.U(1.W))
   }) // (2, 4) * 2 -> (4, 4)
 
   // Debug Utils

--- a/src/main/scala/fudian/RoundingUnit.scala
+++ b/src/main/scala/fudian/RoundingUnit.scala
@@ -20,7 +20,7 @@ class RoundingUnit(val width: Int) extends Module {
   val inexact = r | s
   val r_up = MuxLookup(
     io.rm,
-    false.B,
+    false.B)(
     Seq(
       RNE -> ((r && s) || (r && !s && g)),
       RTZ -> false.B,

--- a/src/main/scala/fudian/utils/Multiplier.scala
+++ b/src/main/scala/fudian/utils/Multiplier.scala
@@ -32,7 +32,7 @@ class Multiplier(len: Int, pipeAt: Seq[Int]) extends Module {
   var last_x = WireInit(0.U(3.W))
   for(i <- Range(0, len, 2)){
     val x = if(i==0) Cat(a(1,0), 0.U(1.W)) else if(i+1==len) SignExt(a(i, i-1), 3) else a(i+1, i-1)
-    val pp_temp = MuxLookup(x, 0.U, Seq(
+    val pp_temp = MuxLookup(x, 0.U)(Seq(
       1.U -> b_sext,
       2.U -> b_sext,
       3.U -> bx2,
@@ -41,7 +41,7 @@ class Multiplier(len: Int, pipeAt: Seq[Int]) extends Module {
       6.U -> neg_b
     ))
     val s = pp_temp(len)
-    val t = MuxLookup(last_x, 0.U(2.W), Seq(
+    val t = MuxLookup(last_x, 0.U(2.W))(Seq(
       4.U -> 2.U(2.W),
       5.U -> 1.U(2.W),
       6.U -> 1.U(2.W)


### PR DESCRIPTION
Some deprecated APIs in chisel 3.6.0 have been deleted in chisel 6.0.0-RC2. This PR replaces them.